### PR TITLE
🎨 Palette: Improve Snapshot feedback and Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-10-18 - HUD Accessibility Patterns
+**Learning:** The custom HUD implementation (`.hud` overlay) often uses dense layouts where standard `<label>` elements are visually omitted, leading to inputs with no accessible name.
+**Action:** Systematically check all HUD inputs and apply `aria-label` to provide context for screen readers while preserving the compact visual design. Also, ensure interactive toggles (like Share panel) use `aria-expanded`.

--- a/langton3d/kaaro.css
+++ b/langton3d/kaaro.css
@@ -99,6 +99,11 @@ body {
     background: rgba(255, 255, 255, 0.1);
 }
 
+.hud__btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}
+
 .hud__btn--danger {
     border-color: rgba(255, 86, 86, 0.35);
 }

--- a/langton3d/kaaro.html
+++ b/langton3d/kaaro.html
@@ -55,7 +55,7 @@
                 <button class="hud__btn hud__btn--danger" id="btn-reset" type="button">Reset</button>
                 <button class="hud__btn" id="btn-fullscreen" type="button" title="Toggle fullscreen">Fullscreen</button>
                 <button class="hud__btn" id="btn-share" type="button" title="Copy a shareable URL preset">Share</button>
-                <button class="hud__btn" id="btn-sharepanel" type="button" title="Open Share/Import panel">Share/Import</button>
+                <button class="hud__btn" id="btn-sharepanel" type="button" title="Open Share/Import panel" aria-expanded="false">Share/Import</button>
                 <button class="hud__btn" id="btn-snapshot" type="button" title="Share/download a snapshot image (includes preset URL)">Snapshot</button>
                 <button class="hud__btn" id="btn-help" type="button" title="Help and controls">Help</button>
                 <label class="hud__label" title="Simulation steps per frame">
@@ -78,11 +78,11 @@
                     <div class="panel">
                         <div class="panel__title">Share</div>
                         <div class="panel__row">
-                            <input class="panel__input" id="shareUrl" type="text" readonly value="" />
+                            <input class="panel__input" id="shareUrl" type="text" readonly value="" aria-label="Shareable URL" />
                             <button class="hud__btn" id="btn-copy-share" type="button">Copy</button>
                         </div>
                         <div class="panel__row">
-                            <input class="panel__input" id="loadPreset" type="text" placeholder="Paste a shared URL or ?p=..." />
+                            <input class="panel__input" id="loadPreset" type="text" placeholder="Paste a shared URL or ?p=..." aria-label="Load preset from URL" />
                             <button class="hud__btn" id="btn-load-preset" type="button">Load</button>
                         </div>
                         <div class="panel__hint">Copy/share the URL. Paste a URL/preset to load without reloading the page.</div>

--- a/langton3d/kaaro.js
+++ b/langton3d/kaaro.js
@@ -521,6 +521,7 @@ function setupHud() {
 
     function toggleSharePanel(forceOpen) {
         var shouldOpen = (typeof forceOpen === 'boolean') ? forceOpen : !sharePanelEl.classList.contains('is-open');
+        sharePanelBtnEl.setAttribute('aria-expanded', shouldOpen ? 'true' : 'false');
         if (shouldOpen) {
             sharePanelEl.classList.add('is-open');
             sharePanelEl.setAttribute('aria-hidden', 'false');
@@ -567,6 +568,11 @@ function setupHud() {
     });
 
     snapshotEl.addEventListener('click', async () => {
+        if (snapshotEl.disabled) return;
+        snapshotEl.disabled = true;
+        var prevText = snapshotEl.textContent;
+        snapshotEl.textContent = 'Snapping...';
+
         var shareUrl = buildShareUrl();
         try {
             var didEnter = await maybeEnterFullscreenForShare();
@@ -580,12 +586,15 @@ function setupHud() {
                     files: [file]
                 });
                 await maybeExitFullscreenAfterShare(didEnter);
+                snapshotEl.textContent = prevText;
+                snapshotEl.disabled = false;
                 return;
             }
             if (file) {
                 downloadFile(file, 'langton3d.png');
                 await copyTextToClipboard(shareUrl);
                 snapshotEl.textContent = 'Downloaded';
+                snapshotEl.disabled = false;
                 setTimeout(() => { snapshotEl.textContent = 'Snapshot'; }, 900);
                 await maybeExitFullscreenAfterShare(didEnter);
                 return;
@@ -597,6 +606,8 @@ function setupHud() {
             await maybeExitFullscreenAfterShare(false);
             console.warn('Preset URL:', shareUrl);
         }
+        snapshotEl.textContent = 'Snapshot';
+        snapshotEl.disabled = false;
     });
 
     spawnFormEl.addEventListener('submit', (event) => {


### PR DESCRIPTION
🎨 **Palette Improvement: Langton 3D Interaction & Accessibility**

💡 **What:**
- Added a "Snapping..." loading state to the **Snapshot** button, which disables the button during the potentially slow image generation process.
- Added missing `aria-label` attributes to the read-only Share URL input and the Load Preset input.
- Added `aria-expanded` state management to the "Share/Import" button.
- Added CSS styles for disabled HUD buttons (`opacity: 0.6`, `cursor: not-allowed`).

🎯 **Why:**
- Users had no visual feedback when clicking "Snapshot", leading to uncertainty if the action was registered, especially on slower devices.
- Screen reader users could not identify the purpose of the text inputs in the Share panel.
- The toggle state of the Share panel was not programmatically communicated.

♿ **Accessibility:**
- **Labels:** Inputs now have "Shareable URL" and "Load preset from URL" accessible names.
- **State:** Share button now correctly reports `aria-expanded="true/false"`.
- **Feedback:** Snapshot button now clearly indicates busy state.


---
*PR created automatically by Jules for task [17575565075680667116](https://jules.google.com/task/17575565075680667116) started by @karx*