### PR TITLE
🎨 Palette: Add accessible labels and focus styles to langton3d HUD

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-10-18 - Missing Focus Styles on HUD Inputs
+**Learning:** The 'langton3d' experiment uses custom inputs (`.panel__input`) that remove the default outline but fail to provide a custom focus state, unlike `.spawn__input`. Additionally, these inputs lack associated labels, making them inaccessible to screen readers and keyboard users.
+**Action:** Ensure all custom inputs in HUD/Panels have explicit `:focus` or `:focus-visible` styles matching the design system (e.g., `rgba(160, 196, 255, 0.55)`) and accessible names (via `aria-label` if visual labels are absent).

--- a/langton3d/kaaro.css
+++ b/langton3d/kaaro.css
@@ -215,6 +215,10 @@ body {
     outline: none;
 }
 
+.panel__input:focus {
+    border-color: rgba(160, 196, 255, 0.55);
+}
+
 .panel__hint {
     font-size: 12px;
     opacity: 0.82;

--- a/langton3d/kaaro.html
+++ b/langton3d/kaaro.html
@@ -78,11 +78,11 @@
                     <div class="panel">
                         <div class="panel__title">Share</div>
                         <div class="panel__row">
-                            <input class="panel__input" id="shareUrl" type="text" readonly value="" />
+                            <input class="panel__input" id="shareUrl" type="text" readonly value="" aria-label="Shareable URL" />
                             <button class="hud__btn" id="btn-copy-share" type="button">Copy</button>
                         </div>
                         <div class="panel__row">
-                            <input class="panel__input" id="loadPreset" type="text" placeholder="Paste a shared URL or ?p=..." />
+                            <input class="panel__input" id="loadPreset" type="text" placeholder="Paste a shared URL or ?p=..." aria-label="Load preset" />
                             <button class="hud__btn" id="btn-load-preset" type="button">Load</button>
                         </div>
                         <div class="panel__hint">Copy/share the URL. Paste a URL/preset to load without reloading the page.</div>


### PR DESCRIPTION
💡 What: Added `aria-label` to Share/Load inputs and implemented visible focus styles (`:focus`).
🎯 Why: The inputs lacked accessible names and visual focus indicators, making them unusable for screen reader and keyboard users.
♿ Accessibility:
- Added `aria-label="Shareable URL"` and `aria-label="Load preset"`.
- Added `.panel__input:focus` with `border-color: rgba(160, 196, 255, 0.55)` to match design system.
Reference: `.Jules/palette.md` (created).

---
*PR created automatically by Jules for task [7413471863715766230](https://jules.google.com/task/7413471863715766230) started by @karx*