### PR TITLE
🎨 Palette: Langton3D UX Polish

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-22 - Async Feedback & Keyboard Discovery
+**Learning:** Users often miss keyboard shortcuts if they are only in help text. Async operations (like WebGL snapshots) without immediate UI feedback feel broken.
+**Action:** Always add `aria-keyshortcuts` to buttons with hotkeys. Always add immediate "loading" state (text change/disable) to buttons triggering async logic.

--- a/langton3d/kaaro.css
+++ b/langton3d/kaaro.css
@@ -459,3 +459,8 @@ body {
     min-height: 16px;
     flex: 1;
 }
+
+.hud__btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}

--- a/langton3d/kaaro.html
+++ b/langton3d/kaaro.html
@@ -50,14 +50,14 @@
                 <div class="hud__hint">WASD/Arrows + mouse to move • Space pause • N step • R reset</div>
             </div>
             <div class="hud__controls">
-                <button class="hud__btn" id="btn-toggle" type="button">Pause</button>
-                <button class="hud__btn" id="btn-step" type="button">Step</button>
-                <button class="hud__btn hud__btn--danger" id="btn-reset" type="button">Reset</button>
+                <button class="hud__btn" id="btn-toggle" type="button" aria-keyshortcuts="Space">Pause</button>
+                <button class="hud__btn" id="btn-step" type="button" aria-keyshortcuts="N">Step</button>
+                <button class="hud__btn hud__btn--danger" id="btn-reset" type="button" aria-keyshortcuts="R">Reset</button>
                 <button class="hud__btn" id="btn-fullscreen" type="button" title="Toggle fullscreen">Fullscreen</button>
                 <button class="hud__btn" id="btn-share" type="button" title="Copy a shareable URL preset">Share</button>
                 <button class="hud__btn" id="btn-sharepanel" type="button" title="Open Share/Import panel">Share/Import</button>
                 <button class="hud__btn" id="btn-snapshot" type="button" title="Share/download a snapshot image (includes preset URL)">Snapshot</button>
-                <button class="hud__btn" id="btn-help" type="button" title="Help and controls">Help</button>
+                <button class="hud__btn" id="btn-help" type="button" title="Help and controls" aria-keyshortcuts="?">Help</button>
                 <label class="hud__label" title="Simulation steps per frame">
                     Speed
                     <input id="speed" type="range" min="1" max="30" value="1" />

--- a/langton3d/kaaro.js
+++ b/langton3d/kaaro.js
@@ -482,7 +482,11 @@ function setupHud() {
     });
 
     toggleSpawnEl.addEventListener('click', () => {
-        spawnFormEl.classList.toggle('is-open');
+        var isOpen = spawnFormEl.classList.toggle('is-open');
+        if (isOpen) {
+            var nameInput = document.getElementById('spawnName');
+            if (nameInput) nameInput.focus();
+        }
     });
 
     function syncFullscreenUi() {
@@ -568,6 +572,10 @@ function setupHud() {
 
     snapshotEl.addEventListener('click', async () => {
         var shareUrl = buildShareUrl();
+        var originalText = snapshotEl.textContent;
+        snapshotEl.disabled = true;
+        snapshotEl.textContent = 'Snapping...';
+
         try {
             var didEnter = await maybeEnterFullscreenForShare();
             await delay(90);
@@ -596,6 +604,11 @@ function setupHud() {
             console.warn('Snapshot failed', err);
             await maybeExitFullscreenAfterShare(false);
             console.warn('Preset URL:', shareUrl);
+        } finally {
+            snapshotEl.disabled = false;
+            if (snapshotEl.textContent === 'Snapping...') {
+                snapshotEl.textContent = originalText;
+            }
         }
     });
 


### PR DESCRIPTION
💡 What: Added loading state to Snapshot button, focus management for Spawn drawer, and `aria-keyshortcuts` to HUD buttons.
🎯 Why: Users had no feedback during snapshot generation (async), spawn form required extra click to focus, and keyboard shortcuts were not programmatically discoverable.
📸 Before/After: Snapshot button now says "Snapping..." and disables during processing.
♿ Accessibility: Added `aria-keyshortcuts` (Space, N, R, ?) and `cursor: not-allowed` for disabled buttons.

---
*PR created automatically by Jules for task [7043117404614942320](https://jules.google.com/task/7043117404614942320) started by @karx*