### PR TITLE
🎨 Palette: Add ARIA labels and shortcut hints

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,7 @@
+## 2024-10-25 - [Accessibility] Discoverable Shortcuts
+**Learning:** `aria-keyshortcuts` is a powerful, low-effort way to bridge the gap between "power user" features (keyboard shortcuts) and accessibility. It exposes existing shortcuts programmatically without requiring UI changes.
+**Action:** Audit all HUD/toolbar buttons for existing keyboard listeners and add corresponding `aria-keyshortcuts` attributes.
+
+## 2024-10-25 - [Accessibility] Invisible Inputs
+**Learning:** Inputs in "compact" panels often rely on placeholders or button proximity for context, failing WCAG 3.3.2 (Labels or Instructions). `aria-label` solves this without cluttering the visual UI.
+**Action:** Always check `input` elements in drawers/modals for `label` tags; if missing for design reasons, mandate `aria-label`.

--- a/langton3d/kaaro.html
+++ b/langton3d/kaaro.html
@@ -50,14 +50,14 @@
                 <div class="hud__hint">WASD/Arrows + mouse to move • Space pause • N step • R reset</div>
             </div>
             <div class="hud__controls">
-                <button class="hud__btn" id="btn-toggle" type="button">Pause</button>
-                <button class="hud__btn" id="btn-step" type="button">Step</button>
-                <button class="hud__btn hud__btn--danger" id="btn-reset" type="button">Reset</button>
+                <button class="hud__btn" id="btn-toggle" type="button" aria-keyshortcuts="Space">Pause</button>
+                <button class="hud__btn" id="btn-step" type="button" aria-keyshortcuts="N">Step</button>
+                <button class="hud__btn hud__btn--danger" id="btn-reset" type="button" aria-keyshortcuts="R">Reset</button>
                 <button class="hud__btn" id="btn-fullscreen" type="button" title="Toggle fullscreen">Fullscreen</button>
                 <button class="hud__btn" id="btn-share" type="button" title="Copy a shareable URL preset">Share</button>
                 <button class="hud__btn" id="btn-sharepanel" type="button" title="Open Share/Import panel">Share/Import</button>
                 <button class="hud__btn" id="btn-snapshot" type="button" title="Share/download a snapshot image (includes preset URL)">Snapshot</button>
-                <button class="hud__btn" id="btn-help" type="button" title="Help and controls">Help</button>
+                <button class="hud__btn" id="btn-help" type="button" title="Help and controls" aria-keyshortcuts="?">Help</button>
                 <label class="hud__label" title="Simulation steps per frame">
                     Speed
                     <input id="speed" type="range" min="1" max="30" value="1" />
@@ -78,11 +78,11 @@
                     <div class="panel">
                         <div class="panel__title">Share</div>
                         <div class="panel__row">
-                            <input class="panel__input" id="shareUrl" type="text" readonly value="" />
+                            <input class="panel__input" id="shareUrl" type="text" readonly value="" aria-label="Share URL" />
                             <button class="hud__btn" id="btn-copy-share" type="button">Copy</button>
                         </div>
                         <div class="panel__row">
-                            <input class="panel__input" id="loadPreset" type="text" placeholder="Paste a shared URL or ?p=..." />
+                            <input class="panel__input" id="loadPreset" type="text" placeholder="Paste a shared URL or ?p=..." aria-label="Load preset" />
                             <button class="hud__btn" id="btn-load-preset" type="button">Load</button>
                         </div>
                         <div class="panel__hint">Copy/share the URL. Paste a URL/preset to load without reloading the page.</div>


### PR DESCRIPTION
💡 What: Added `aria-label` to Share/Import inputs and `aria-keyshortcuts` to HUD buttons.
🎯 Why: Improves accessibility for screen reader users by providing names for label-less inputs and exposing keyboard shortcuts programmatically.
♿ Accessibility:
- Inputs `#shareUrl` and `#loadPreset` now have accessible names.
- Buttons for Pause, Step, Reset, Help now announce their shortcuts (Space, N, R, ?).

---
*PR created automatically by Jules for task [12285294373480386936](https://jules.google.com/task/12285294373480386936) started by @karx*