### PR TITLE
🎨 Palette: Add keyboard shortcut hints for accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,5 @@
+# Palette's Journal
+
+## 2026-02-01 - Exposing Custom Keyboard Shortcuts
+**Learning:** Custom JavaScript keyboard listeners (e.g., `document.addEventListener('keydown')`) are invisible to screen readers, leaving users unaware of available shortcuts.
+**Action:** Always add `aria-keyshortcuts` attributes to the corresponding UI controls to explicitly announce these shortcuts (e.g., `aria-keyshortcuts="Space"` on the Pause button).

--- a/langton3d/kaaro.html
+++ b/langton3d/kaaro.html
@@ -50,14 +50,14 @@
                 <div class="hud__hint">WASD/Arrows + mouse to move • Space pause • N step • R reset</div>
             </div>
             <div class="hud__controls">
-                <button class="hud__btn" id="btn-toggle" type="button">Pause</button>
-                <button class="hud__btn" id="btn-step" type="button">Step</button>
-                <button class="hud__btn hud__btn--danger" id="btn-reset" type="button">Reset</button>
+                <button class="hud__btn" id="btn-toggle" type="button" aria-keyshortcuts="Space">Pause</button>
+                <button class="hud__btn" id="btn-step" type="button" aria-keyshortcuts="n">Step</button>
+                <button class="hud__btn hud__btn--danger" id="btn-reset" type="button" aria-keyshortcuts="r">Reset</button>
                 <button class="hud__btn" id="btn-fullscreen" type="button" title="Toggle fullscreen">Fullscreen</button>
                 <button class="hud__btn" id="btn-share" type="button" title="Copy a shareable URL preset">Share</button>
                 <button class="hud__btn" id="btn-sharepanel" type="button" title="Open Share/Import panel">Share/Import</button>
                 <button class="hud__btn" id="btn-snapshot" type="button" title="Share/download a snapshot image (includes preset URL)">Snapshot</button>
-                <button class="hud__btn" id="btn-help" type="button" title="Help and controls">Help</button>
+                <button class="hud__btn" id="btn-help" type="button" title="Help and controls" aria-keyshortcuts="?">Help</button>
                 <label class="hud__label" title="Simulation steps per frame">
                     Speed
                     <input id="speed" type="range" min="1" max="30" value="1" />


### PR DESCRIPTION
- Added `aria-keyshortcuts="Space"` to Pause button.
- Added `aria-keyshortcuts="n"` to Step button.
- Added `aria-keyshortcuts="r"` to Reset button.
- Added `aria-keyshortcuts="?"` to Help button.
- Created `.Jules/palette.md` with an entry about exposing keyboard shortcuts.
- Verified using a Python HTML parser script and visual frontend verification.

---
*PR created automatically by Jules for task [15314305381276363762](https://jules.google.com/task/15314305381276363762) started by @karx*