### PR TITLE
🎨 Palette: Add snapshot loading state & fix inputs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,7 @@
+## 2024-10-24 - [Manual UI State Management]
+**Learning:** The 'langton3d' experiment relies on manual DOM manipulation for UI states (loading, disabled) rather than reactive frameworks or CSS state classes.
+**Action:** When implementing async features, manually toggle `disabled` attributes and text content to prevent race conditions and provide feedback.
+
+## 2024-10-24 - [Implicit Form Labels]
+**Learning:** HUD inputs in 'langton3d' often lack associated `<label>` elements, relying on visual layout.
+**Action:** Always check for and add `aria-label` to inputs in the HUD or side panels to ensure screen reader accessibility.

--- a/langton3d/kaaro.html
+++ b/langton3d/kaaro.html
@@ -78,11 +78,11 @@
                     <div class="panel">
                         <div class="panel__title">Share</div>
                         <div class="panel__row">
-                            <input class="panel__input" id="shareUrl" type="text" readonly value="" />
+                            <input class="panel__input" id="shareUrl" aria-label="Share URL" type="text" readonly value="" />
                             <button class="hud__btn" id="btn-copy-share" type="button">Copy</button>
                         </div>
                         <div class="panel__row">
-                            <input class="panel__input" id="loadPreset" type="text" placeholder="Paste a shared URL or ?p=..." />
+                            <input class="panel__input" id="loadPreset" aria-label="Load preset URL" type="text" placeholder="Paste a shared URL or ?p=..." />
                             <button class="hud__btn" id="btn-load-preset" type="button">Load</button>
                         </div>
                         <div class="panel__hint">Copy/share the URL. Paste a URL/preset to load without reloading the page.</div>

--- a/langton3d/kaaro.js
+++ b/langton3d/kaaro.js
@@ -568,6 +568,9 @@ function setupHud() {
 
     snapshotEl.addEventListener('click', async () => {
         var shareUrl = buildShareUrl();
+        snapshotEl.disabled = true;
+        snapshotEl.textContent = 'Snapping...';
+
         try {
             var didEnter = await maybeEnterFullscreenForShare();
             await delay(90);
@@ -586,7 +589,10 @@ function setupHud() {
                 downloadFile(file, 'langton3d.png');
                 await copyTextToClipboard(shareUrl);
                 snapshotEl.textContent = 'Downloaded';
-                setTimeout(() => { snapshotEl.textContent = 'Snapshot'; }, 900);
+                setTimeout(() => {
+                    snapshotEl.textContent = 'Snapshot';
+                    snapshotEl.disabled = false;
+                }, 900);
                 await maybeExitFullscreenAfterShare(didEnter);
                 return;
             }
@@ -596,6 +602,11 @@ function setupHud() {
             console.warn('Snapshot failed', err);
             await maybeExitFullscreenAfterShare(false);
             console.warn('Preset URL:', shareUrl);
+        } finally {
+            if (snapshotEl.textContent !== 'Downloaded') {
+                snapshotEl.textContent = 'Snapshot';
+                snapshotEl.disabled = false;
+            }
         }
     });
 


### PR DESCRIPTION
Implemented micro-UX improvements for Langton 3D:
1.  **Accessibility**: Added `aria-label` to the `#shareUrl` and `#loadPreset` inputs in `kaaro.html` to fix missing accessible names.
2.  **Interaction Feedback**: Updated `kaaro.js` to disable the Snapshot button and change its text to "Snapping..." while the potentially slow snapshot generation is in progress. This provides visual feedback and prevents re-triggering. The button state is reliably restored after success or failure.

---
*PR created automatically by Jules for task [2568337962662668263](https://jules.google.com/task/2568337962662668263) started by @karx*