### PR TITLE
🎨 Palette: Auto-focus Name input in Ant Drawer

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-03 - Auto-focus in Custom Drawers
+**Learning:** Custom UI drawers (non-native dialogs) don't manage focus automatically. Users expect input focus immediately upon opening a form-like drawer.
+**Action:** Always add explicit `.focus()` logic when toggling visibility of custom input containers.

--- a/langton3d/kaaro.js
+++ b/langton3d/kaaro.js
@@ -482,7 +482,11 @@ function setupHud() {
     });
 
     toggleSpawnEl.addEventListener('click', () => {
-        spawnFormEl.classList.toggle('is-open');
+        var isOpen = spawnFormEl.classList.toggle('is-open');
+        if (isOpen) {
+            var nameInput = document.getElementById('spawnName');
+            if (nameInput) nameInput.focus();
+        }
     });
 
     function syncFullscreenUi() {


### PR DESCRIPTION
💡 What: Added auto-focus to the "Name" input field when the "Add Ant" drawer is opened.
🎯 Why: To reduce friction and clicks for the user. When opening a form, the user's intent is almost always to fill it out.
📸 Before/After: (Behavioral change) Focus now jumps to the input immediately.
♿ Accessibility: Improved keyboard efficiency for adding new ants.

---
*PR created automatically by Jules for task [2896516810299935831](https://jules.google.com/task/2896516810299935831) started by @karx*