### PR TITLE
🎨 Palette: Consistent Focus Styles for Langton3D

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-04 - Consistent Focus States in Custom UI
+**Learning:** Custom UI components (like `.hud__btn`) often lose default browser focus indicators, making keyboard navigation impossible. Relying solely on `hover` states excludes keyboard users.
+**Action:** Always verify keyboard focus visibility when styling custom buttons and ensure a consistent focus ring style (e.g., using `box-shadow` or `border-color`) is applied across all interactive elements.

--- a/langton3d/kaaro.css
+++ b/langton3d/kaaro.css
@@ -64,6 +64,12 @@ body {
     background: rgba(255, 255, 255, 0.10);
 }
 
+.hud__link:focus-visible {
+    outline: none;
+    border-color: rgba(160, 196, 255, 0.55);
+    box-shadow: 0 0 0 1px rgba(160, 196, 255, 0.55);
+}
+
 .hud__hint {
     margin-top: 4px;
     font-size: 12px;
@@ -97,6 +103,12 @@ body {
 
 .hud__btn:hover {
     background: rgba(255, 255, 255, 0.1);
+}
+
+.hud__btn:focus-visible {
+    outline: none;
+    border-color: rgba(160, 196, 255, 0.55);
+    box-shadow: 0 0 0 1px rgba(160, 196, 255, 0.55);
 }
 
 .hud__btn--danger {
@@ -215,6 +227,10 @@ body {
     outline: none;
 }
 
+.panel__input:focus {
+    border-color: rgba(160, 196, 255, 0.55);
+}
+
 .panel__hint {
     font-size: 12px;
     opacity: 0.82;
@@ -253,6 +269,12 @@ body {
 
 .presetBtn:hover {
     background: rgba(255, 255, 255, 0.10);
+}
+
+.presetBtn:focus-visible {
+    outline: none;
+    border-color: rgba(160, 196, 255, 0.55);
+    box-shadow: 0 0 0 1px rgba(160, 196, 255, 0.55);
 }
 
 .modal {


### PR DESCRIPTION
Implemented consistent focus styles for keyboard navigation in `langton3d` experiment.
- Used `outline: none` and `border-color` + `box-shadow` for buttons to create a visible focus ring without layout shifts.
- Used `border-color` for inputs to match existing `.spawn__input` style.
- Verified with Playwright script and screenshot.
- Added journal entry.

---
*PR created automatically by Jules for task [7825363089639154655](https://jules.google.com/task/7825363089639154655) started by @karx*