### PR TITLE
🎨 Palette: Improve accessibility of Share panel inputs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-05 - Hidden Labels in Utility Panels
+**Learning:** Utility inputs (like copy-paste URLs) often rely on context/placeholders and miss accessible labels, which blocks screen reader users. Also, `outline: none` without a focus replacement is a common oversight in these custom panels.
+**Action:** Always audit "utility" or "tool" panels for inputs that might have been treated as "visual only" and ensure they have `aria-label` and visible focus states.

--- a/langton3d/kaaro.css
+++ b/langton3d/kaaro.css
@@ -215,6 +215,10 @@ body {
     outline: none;
 }
 
+.panel__input:focus {
+    border-color: rgba(160, 196, 255, 0.55);
+}
+
 .panel__hint {
     font-size: 12px;
     opacity: 0.82;

--- a/langton3d/kaaro.html
+++ b/langton3d/kaaro.html
@@ -78,11 +78,11 @@
                     <div class="panel">
                         <div class="panel__title">Share</div>
                         <div class="panel__row">
-                            <input class="panel__input" id="shareUrl" type="text" readonly value="" />
+                            <input class="panel__input" id="shareUrl" type="text" readonly value="" aria-label="Shareable URL" />
                             <button class="hud__btn" id="btn-copy-share" type="button">Copy</button>
                         </div>
                         <div class="panel__row">
-                            <input class="panel__input" id="loadPreset" type="text" placeholder="Paste a shared URL or ?p=..." />
+                            <input class="panel__input" id="loadPreset" type="text" placeholder="Paste a shared URL or ?p=..." aria-label="Load preset from URL or code" />
                             <button class="hud__btn" id="btn-load-preset" type="button">Load</button>
                         </div>
                         <div class="panel__hint">Copy/share the URL. Paste a URL/preset to load without reloading the page.</div>


### PR DESCRIPTION
This PR addresses accessibility issues in the Share/Import panel of the `langton3d` experiment.
- **What:** Added `aria-label` attributes to the `#shareUrl` and `#loadPreset` inputs and added a `:focus` CSS rule for `.panel__input`.
- **Why:** Screen reader users could not identify the purpose of these inputs, and keyboard users lost focus context due to `outline: none` without a replacement style.
- **Verification:** Verified programmatically via Python script and visually via Playwright screenshot.
- **Learnings:** Documented the importance of explicit labeling for utility inputs and focus management in `.Jules/palette.md`.

---
*PR created automatically by Jules for task [14581329294992653549](https://jules.google.com/task/14581329294992653549) started by @karx*