### PR TITLE
🎨 Palette: Auto-focus Name input in Add Ant drawer

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-02-06 - Manual Focus Management for Custom Drawers
+**Learning:** Custom UI components like drawers (`.drawer` in this repo) do not manage focus automatically like native `<dialog>` elements. Users can get lost if focus isn't moved to the drawer content.
+**Action:** When toggling a custom drawer open, explicitly focus the first interactive element (e.g., input) to improve keyboard accessibility and usability.

--- a/langton3d/kaaro.js
+++ b/langton3d/kaaro.js
@@ -482,7 +482,11 @@ function setupHud() {
     });
 
     toggleSpawnEl.addEventListener('click', () => {
-        spawnFormEl.classList.toggle('is-open');
+        var isOpen = spawnFormEl.classList.toggle('is-open');
+        if (isOpen) {
+            var nameInput = document.getElementById('spawnName');
+            if (nameInput) nameInput.focus();
+        }
     });
 
     function syncFullscreenUi() {


### PR DESCRIPTION
💡 What: Added logic to automatically focus the 'Name' input field when the 'Add Ant' drawer is opened.
🎯 Why: Reduces friction for users adding new ants by removing the need to click the input field, improving keyboard accessibility and efficiency.
📸 Before/After: Verified with Playwright screenshot showing the input receives focus.
♿ Accessibility: Improves focus management for keyboard users.

---
*PR created automatically by Jules for task [12158605097240800257](https://jules.google.com/task/12158605097240800257) started by @karx*